### PR TITLE
Remove use of pkg_resources in favour of importlib

### DIFF
--- a/flake8_commas/_base.py
+++ b/flake8_commas/_base.py
@@ -1,13 +1,11 @@
 import collections
+import importlib.metadata
 import token as mod_token
 import tokenize
 
-import pkg_resources
-
 try:
-    dist = pkg_resources.get_distribution('flake8-commas')
-    __version__ = dist.version
-except pkg_resources.DistributionNotFound:
+    __version__ = importlib.metadata.version('flake8-commas')
+except importlib.metadata.PackageNotFoundError:
     __version__ = 'unknown'
 
 # A parenthesized expression list yields whatever that expression list


### PR DESCRIPTION
Hi, I see you've added some support for Python 3.11, which is great :). I was wondering if you'd be up for packaging up a fork of flake8-commas & publishing on PyPI to support members of the community who want to keep using it? (There's definitely interest, see for example https://github.com/wemake-services/wemake-python-styleguide/issues/2276)

This PR removes use of deprecated `pkg_resources`, which likely helps with that.

No worries if not -- in that case I might do so myself.